### PR TITLE
docs: Add Windows gcloud setup heads up to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ gcloud auth application-default login
 * [Telegram Bot Token](https://core.telegram.org/bots/tutorial#obtain-your-bot-token)
 * [Gemini API Key](https://aistudio.google.com/api-keys) (use Free Tier for Free)
 
+**Heads up:** Setting up gcloud on Windows can sometimes be tricky.
+Check this [guide](https://docs.cloud.google.com/sdk/docs/install-sdk) and ask your AI agent for help.
+Make sure before proceeding further that commands like ```gcloud auth list``` work otherwise the script will fail
+
 ## 🚀 One command deployment 
 
 > ⏱️ ~5 minutes from zero to live bot


### PR DESCRIPTION
Added a note in the prerequisites section warning about potential issues with gcloud setup on Windows, including a link to the official installation guide and a reminder to verify gcloud commands work before proceeding with deployment.